### PR TITLE
Fix typo

### DIFF
--- a/imageroot/actions/get-configuration/validate-output.json
+++ b/imageroot/actions/get-configuration/validate-output.json
@@ -14,7 +14,7 @@
     "type": "object",
     "required": [
     "charset",
-    "port,"
+    "port",
     "tz",
     "host",
         "http2https",


### PR DESCRIPTION
There's a typo which throws an error at the status page. There's still some other error in that file that is thrown on the settings page but I didn't find it.